### PR TITLE
Fix for a minor issue with get_jetton_data

### DIFF
--- a/contracts/pool/utils.func
+++ b/contracts/pool/utils.func
@@ -73,7 +73,9 @@ slice address_to_hex_string(int value) inline {
     int mask = 15;
     builder buffer = begin_cell();
 
-    while (value != 0) {
+    int i = 64;
+    while (i > 0) {
+      i -= 1;
       int curr = (value & mask);
       if(curr > 9){
         buffer = buffer.store_uint(55 + curr, 8);


### PR DESCRIPTION
Here is a small patch to mitigate a minor issue with ``get_jetton_data``. 
It doesn't affect contract security in any manner but leads to significant problems during new pools discovery for ston.fi and other projects built on top of the ston.fi source code